### PR TITLE
Sync android and IOS versions numbers

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "privacy": "public",
     "sdkVersion": "28.0.0",
     "platforms": ["ios", "android"],
-    "version": "7.1.0",
+    "version": "8.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {
@@ -28,7 +28,7 @@
       "bundleIdentifier" : "ca.usherbrooke.gel.de"
     },
     "android" : {
-      "versionCode" : 8,
+      "versionCode" : 8.1,
       "package" : "ca.usherbrooke.gel.de",
       "permissions" : []
     }


### PR DESCRIPTION
I tried to sync android and IOS versions numbers so we don't have equivalent code release with different version numbers.

From now on we should update to two different places.
